### PR TITLE
役満（Yakuman）の実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   TILES,
   TILE_DISPLAY,
   sortHand,
   calculateScore,
   type Tile,
+  type Meld,
+  type MeldType,
   type AgariOptions,
   type CalculationResult
 } from '@/lib/mahjong';
@@ -22,14 +24,60 @@ export default function Home() {
   const [riichi, setRiichi] = useState<boolean>(false);
   const [ippatsu, setIppatsu] = useState<boolean>(false);
   const [menzen, setMenzen] = useState<boolean>(true);
+  const [melds, setMelds] = useState<Meld[]>([]);
+  const [meldInput, setMeldInput] = useState<Tile[]>([]);
+  const [meldType, setMeldType] = useState<MeldType>('chii');
+  const [isTenhou, setIsTenhou] = useState<boolean>(false);
+  const [isChiihou, setIsChiihou] = useState<boolean>(false);
+
+  // 鳴きがある場合は門前をfalseに設定
+  useEffect(() => {
+    if (melds.length > 0) {
+      setMenzen(false);
+      setRiichi(false);
+    }
+  }, [melds]);
 
   const addTileToHand = (tile: Tile) => {
-    if (hand.length >= 13) {
+    const meldTileCount = melds.reduce((sum, m) => sum + m.tiles.length, 0);
+    const maxHandSize = 14 - meldTileCount - 1;
+
+    if (hand.length >= maxHandSize) {
       setWinningTile(tile);
       return;
     }
     setHand(sortHand([...hand, tile]));
     setError('');
+  };
+
+  const addTileToMeld = (tile: Tile) => {
+    const requiredTiles = meldType === 'ankan' || meldType === 'minkan' ? 4 : 3;
+    if (meldInput.length < requiredTiles) {
+      setMeldInput([...meldInput, tile]);
+    }
+  };
+
+  const removeTileFromMeld = (index: number) => {
+    const newMeldInput = [...meldInput];
+    newMeldInput.splice(index, 1);
+    setMeldInput(newMeldInput);
+  };
+
+  const addMeld = () => {
+    const requiredTiles = meldType === 'ankan' || meldType === 'minkan' ? 4 : 3;
+    if (meldInput.length !== requiredTiles) {
+      setError(`${requiredTiles}枚の牌を選択してください`);
+      return;
+    }
+    setMelds([...melds, { type: meldType, tiles: meldInput }]);
+    setMeldInput([]);
+    setError('');
+  };
+
+  const removeMeld = (index: number) => {
+    const newMelds = [...melds];
+    newMelds.splice(index, 1);
+    setMelds(newMelds);
   };
 
   const setWinningTileHandler = (tile: Tile) => {
@@ -52,6 +100,8 @@ export default function Home() {
     setWinningTile(null);
     setResult(null);
     setError('');
+    setMelds([]);
+    setMeldInput([]);
   };
 
   const handleCalculate = () => {
@@ -66,7 +116,10 @@ export default function Home() {
       jikaze,
       isRiichi: riichi,
       isIppatsu: ippatsu,
-      isMenzen: menzen
+      isMenzen: menzen,
+      melds: melds.length > 0 ? melds : undefined,
+      isTenhou,
+      isChiihou
     };
 
     const calcResult = calculateScore(hand, winningTile, options);
@@ -151,7 +204,7 @@ export default function Home() {
       <div className="section">
         <div className="section-title">現在の手牌</div>
         <div className="hand-display">
-          <div className="hand-title">手牌 (<span>{hand.length}</span>/13枚)</div>
+          <div className="hand-title">手牌 (<span>{hand.length}</span>/{14 - melds.reduce((sum, m) => sum + m.tiles.length, 0) - 1}枚)</div>
           <div className="hand-tiles">
             {hand.map((tile, index) => (
               <div
@@ -165,6 +218,96 @@ export default function Home() {
           </div>
           <div className="info-text">※ 手牌は自動的にソートされます。</div>
         </div>
+
+        {/* 鳴き表示 */}
+        <div className="hand-display" style={{ marginTop: '15px' }}>
+          <div className="hand-title">鳴き（副露） (<span>{melds.length}</span>回）</div>
+          <div className="melds-container">
+            {melds.map((meld, index) => (
+              <div key={index} className="meld-group" onClick={() => removeMeld(index)}>
+                <div className="meld-type">
+                  {meld.type === 'chii' && 'チー'}
+                  {meld.type === 'pon' && 'ポン'}
+                  {meld.type === 'minkan' && '明カン'}
+                  {meld.type === 'ankan' && '暗カン'}
+                </div>
+                <div className="meld-tiles">
+                  {meld.tiles.map((tile, tileIndex) => (
+                    <div key={tileIndex} className="hand-tile" style={{ fontSize: '14px' }}>
+                      {TILE_DISPLAY[tile]}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="info-text">※ クリックして削除できます。</div>
+        </div>
+
+        {/* 鳴き入力 */}
+        <div className="hand-display" style={{ marginTop: '15px' }}>
+          <div className="hand-title">鳴きを追加</div>
+          <div className="option-group" style={{ marginBottom: '10px' }}>
+            <select
+              value={meldType}
+              onChange={(e) => setMeldType(e.target.value as MeldType)}
+              style={{ padding: '5px', fontSize: '14px' }}
+            >
+              <option value="chii">チー（順子）</option>
+              <option value="pon">ポン（刻子）</option>
+              <option value="minkan">明カン（槓子）</option>
+              <option value="ankan">暗カン（槓子）</option>
+            </select>
+          </div>
+          <div className="tile-selector" style={{ fontSize: '12px', marginBottom: '10px' }}>
+            <div style={{ marginBottom: '5px', fontWeight: 'bold' }}>牌を選択:</div>
+            <div className="tile-group">
+              <div className="tiles">
+                {[...TILES.manzu, ...TILES.pinzu, ...TILES.souzu, ...TILES.jihai].map(tile => (
+                  <div
+                    key={tile}
+                    className="tile"
+                    style={{ fontSize: '12px', padding: '3px 5px' }}
+                    onClick={() => addTileToMeld(tile)}
+                  >
+                    {TILE_DISPLAY[tile]}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="hand-tiles">
+            {meldInput.map((tile, index) => (
+              <div
+                key={index}
+                className="hand-tile"
+                onClick={() => removeTileFromMeld(index)}
+              >
+                {TILE_DISPLAY[tile]}
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: '10px', display: 'flex', gap: '10px' }}>
+            <button
+              className="btn btn-primary"
+              onClick={addMeld}
+              disabled={meldInput.length === 0}
+            >
+              鳴きを確定
+            </button>
+            <button
+              className="btn"
+              onClick={() => setMeldInput([])}
+              disabled={meldInput.length === 0}
+            >
+              入力をクリア
+            </button>
+          </div>
+          <div className="info-text" style={{ marginTop: '10px' }}>
+            ※ チー・ポンは3枚、カンは4枚選択してください。
+          </div>
+        </div>
+
         <div className="hand-display" style={{ marginTop: '15px' }}>
           <div className="hand-title">和了牌 (<span>{winningTile ? 1 : 0}</span>/1枚)</div>
           <div className="hand-tiles">
@@ -338,6 +481,40 @@ export default function Home() {
               </label>
             </div>
           </div>
+          <div className="option-group">
+            <div className="option-title">役満（特殊条件）</div>
+            <div className="checkbox-group">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={isTenhou}
+                  onChange={(e) => {
+                    setIsTenhou(e.target.checked);
+                    if (e.target.checked) {
+                      setIsChiihou(false);
+                      setJikaze('ton');
+                    }
+                  }}
+                  disabled={jikaze !== 'ton'}
+                />
+                天和（親の配牌時和了）
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={isChiihou}
+                  onChange={(e) => {
+                    setIsChiihou(e.target.checked);
+                    if (e.target.checked) {
+                      setIsTenhou(false);
+                    }
+                  }}
+                  disabled={jikaze === 'ton'}
+                />
+                地和（子の第一ツモ和了）
+              </label>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -376,8 +553,20 @@ export default function Home() {
                 成立役
               </div>
               {result.yaku.map((yaku, index) => (
-                <div key={index} className="yaku-item">
-                  <span>{yaku.name}</span>
+                <div
+                  key={index}
+                  className="yaku-item"
+                  style={yaku.han >= 13 ? {
+                    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                    color: 'white',
+                    fontWeight: 'bold',
+                    fontSize: '1.1em',
+                    padding: '12px 15px',
+                    border: '2px solid #ffd700',
+                    boxShadow: '0 4px 15px rgba(102, 126, 234, 0.4)'
+                  } : {}}
+                >
+                  <span>{yaku.han >= 13 ? '🏆 ' : ''}{yaku.name}</span>
                   <span>{yaku.han}翻</span>
                 </div>
               ))}


### PR DESCRIPTION
## 概要
Issue #4で要求された役満（Yakuman）の実装を完了しました。10種類の役満手を検出できるようになりました。

## 実装された役満

### 通常役満（13翻）
- **国士無双（Kokushi Musou）**: 13種類のヤオチュー牌（1,9,字牌）
- **四暗刻（Suu Ankou）**: 4つの暗刻
- **大三元（Daisangen）**: 白、發、中の3種類すべてが刻子
- **字一色（Tsuuiisou）**: 字牌のみで構成
- **緑一色（Ryuuiisou）**: 2,3,4,6,8索と發のみで構成
- **清老頭（Chinroutou）**: 1と9のみで構成
- **九蓮宝燈（Chuuren Poutou）**: 門前で1つの色、1112345678999の形+1枚
- **小四喜（Shousuushii）**: 4種の風牌のうち3つが刻子、1つが雀頭

### ダブル役満（26翻）
- **大四喜（Daisuushii）**: 4種の風牌すべてが刻子

### 特殊役満（13翻）
- **天和（Tenhou）**: 親の配牌時和了
- **地和（Chiihou）**: 子の第一ツモ和了

## 実装の詳細

### バックエンド（lib/mahjong.ts）
- 各役満の検出関数を実装
- detectYaku関数を更新して役満を優先的にチェック
- AgariOptionsインターフェースにisTenhouとisChiihouを追加

### フロントエンド（app/page.tsx）
- 天和と地和のチェックボックスを追加
- 役満を金色のグラデーション背景で強調表示
- トロフィー絵文字（🏆）を役満に追加

## テスト
- ビルドテストを実行し、エラーがないことを確認
- TypeScriptの型チェックが通ることを確認

## 関連Issue
Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)