### PR TITLE
Handle kan meld hand size (fixes #15)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,9 @@ import {
   type CalculationResult
 } from '@/lib/mahjong';
 
+const getMeldTileCount = (meldList: Meld[]): number =>
+  meldList.reduce((sum, meld) => sum + (meld.tiles.length === 4 ? 3 : meld.tiles.length), 0);
+
 export default function Home() {
   const [hand, setHand] = useState<Tile[]>([]);
   const [winningTile, setWinningTile] = useState<Tile | null>(null);
@@ -39,7 +42,7 @@ export default function Home() {
   }, [melds]);
 
   const addTileToHand = (tile: Tile) => {
-    const meldTileCount = melds.reduce((sum, m) => sum + m.tiles.length, 0);
+    const meldTileCount = getMeldTileCount(melds);
     const maxHandSize = 14 - meldTileCount - 1;
 
     if (hand.length >= maxHandSize) {
@@ -204,7 +207,7 @@ export default function Home() {
       <div className="section">
         <div className="section-title">現在の手牌</div>
         <div className="hand-display">
-          <div className="hand-title">手牌 (<span>{hand.length}</span>/{14 - melds.reduce((sum, m) => sum + m.tiles.length, 0) - 1}枚)</div>
+          <div className="hand-title">手牌 (<span>{hand.length}</span>/{14 - getMeldTileCount(melds) - 1}枚)</div>
           <div className="hand-tiles">
             {hand.map((tile, index) => (
               <div

--- a/lib/mahjong.ts
+++ b/lib/mahjong.ts
@@ -222,6 +222,11 @@ function getAllTiles(hand: Tile[], melds?: Meld[]): Tile[] {
   return tiles;
 }
 
+function getMeldTileContribution(melds?: Meld[]): number {
+  if (!melds) return 0;
+  return melds.reduce((sum, meld) => sum + (meld.tiles.length === 4 ? 3 : meld.tiles.length), 0);
+}
+
 function isHonorTile(tile: Tile): boolean {
   return tile.length === 1;
 }
@@ -1329,7 +1334,7 @@ export function calculateScore(
   options: AgariOptions
 ): CalculationResult | { error: string } {
   const melds = options.melds || [];
-  const meldTileCount = melds.reduce((sum, meld) => sum + meld.tiles.length, 0);
+  const meldTileCount = getMeldTileContribution(melds);
   const expectedHandSize = 14 - meldTileCount;
 
   if (hand.length !== expectedHandSize - 1) {


### PR DESCRIPTION
Fixes #15.

## 概要
- カンを選択した際の手牌上限計算を3枚消費に変更
- スコア計算時の必要手牌枚数も同様に調整

## テスト
- `npm run lint` ※対話的セットアップが発生するため未実行
