### PR TITLE
Treat closed kans as menzen (fixes #27)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,13 +53,20 @@ export default function Home() {
     return false;
   };
 
-  // 鳴きがある場合は門前をfalseに設定
+  // 鳴きの状態に応じて門前/リーチを制御（暗槓は門前扱い）
   useEffect(() => {
-    if (melds.length > 0) {
-      setMenzen(false);
-      setRiichi(false);
+    const hasOpenMeld = melds.some(meld => meld.type !== 'ankan');
+    if (hasOpenMeld) {
+      if (menzen) {
+        setMenzen(false);
+      }
+      if (riichi) {
+        setRiichi(false);
+      }
+    } else if (!menzen) {
+      setMenzen(true);
     }
-  }, [melds]);
+  }, [melds, menzen, riichi]);
 
   const addTileToHand = (tile: Tile) => {
     const meldTileCount = getMeldTileCount(melds);


### PR DESCRIPTION
Fixes #27.

## 変更点
- 暗槓のみの場合は門前扱いとし、リーチ/門前状態が維持されるようにUIロジックを修正
- 役判定・符計算で "鳴き" 判定に暗槓を含めないようにし、清一色などの翻数計算も正しくなるよう調整
- `calculateScore` から検出/符計算へ渡す門前フラグを暗槓有無で補正

## テスト
- `npm run lint`
- `npm run test`
