### PR TITLE
Expand mahjong logic tests (fixes #7)

### DIFF
--- a/tests/mahjong.test.ts
+++ b/tests/mahjong.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  calculateFu,
+  calculateFinalScore,
   calculateScore,
   detectYaku,
+  isWinningHand,
   type AgariOptions,
   type Tile,
 } from '../lib/mahjong';
@@ -15,7 +18,63 @@ const baseOptions: AgariOptions = {
   isIppatsu: false,
   isMenzen: true,
   isOya: false,
+  doraTiles: [],
+  uraDoraTiles: [],
+  redDora: { man: 0, pin: 0, sou: 0 },
 };
+
+describe('isWinningHand', () => {
+  it('recognizes a standard hand', () => {
+    const hand: Tile[] = ['1m', '1m', '2m', '3m', '4m', '4p', '5p', '6p', '2s', '3s', '4s', '6s', '7s', '8s'];
+    expect(isWinningHand(hand)).toBe(true);
+  });
+
+  it('recognizes seven pairs', () => {
+    const hand: Tile[] = ['1m', '1m', '2m', '2m', '3p', '3p', '4p', '4p', '5s', '5s', '6s', '6s', '東', '東'];
+    expect(isWinningHand(hand)).toBe(true);
+  });
+
+  it('recognizes kokushi musou', () => {
+    const hand: Tile[] = ['1m', '9m', '1p', '9p', '1s', '9s', '東', '南', '西', '北', '白', '發', '中', '1m'];
+    expect(isWinningHand(hand)).toBe(true);
+  });
+
+  it('rejects an invalid shape', () => {
+    const hand: Tile[] = ['1m', '1m', '1m', '2m', '2m', '2m', '3m', '3m', '3m', '4m', '4m', '4m', '5m', '5p'];
+    expect(isWinningHand(hand)).toBe(false);
+  });
+});
+
+describe('yaku detection', () => {
+  it('detects Tanyao', () => {
+    const fullHand: Tile[] = ['2m', '3m', '4m', '5p', '6p', '7p', '2s', '3s', '4s', '5s', '6s', '7s', '3m', '3m'];
+    const yaku = detectYaku(fullHand, '3m', { ...baseOptions });
+    expect(yaku.map(y => y.name)).toContain('断么九');
+  });
+
+  it('detects Toitoihou', () => {
+    const fullHand: Tile[] = ['1m', '1m', '1m', '3m', '3m', '3m', '5p', '5p', '5p', '7s', '7s'];
+    const yaku = detectYaku(fullHand, '7s', {
+      ...baseOptions,
+      isTsumo: false,
+      isMenzen: false,
+      melds: [{ type: 'pon', tiles: ['東', '東', '東'] }],
+    });
+    expect(yaku.map(y => y.name)).toContain('対々和');
+  });
+
+  it('detects Honitsu', () => {
+    const fullHand: Tile[] = ['1p', '1p', '1p', '2p', '3p', '4p', '5p', '6p', '7p', '8p', '8p', '8p', '東', '東'];
+    const yaku = detectYaku(fullHand, '東', { ...baseOptions });
+    expect(yaku.map(y => y.name)).toContain('混一色');
+  });
+
+  it('detects Chinitsu', () => {
+    const fullHand: Tile[] = ['1s', '2s', '3s', '4s', '5s', '6s', '7s', '7s', '7s', '8s', '8s', '8s', '9s', '9s'];
+    const yaku = detectYaku(fullHand, '9s', { ...baseOptions });
+    expect(yaku.map(y => y.name)).toContain('清一色');
+  });
+});
 
 describe('mahjong scoring', () => {
   it('calculates Pinfu tsumo correctly', () => {
@@ -78,6 +137,47 @@ describe('mahjong scoring', () => {
     expect(yakuNames).toContain('ドラ2');
     expect(yakuNames).toContain('裏ドラ1');
     expect(yakuNames).toContain('赤ドラ1');
+  });
+});
+
+describe('calculateFu', () => {
+  it('returns 25 for seven pairs', () => {
+    const tiles: Tile[] = ['1m', '1m', '2m', '2m', '3p', '3p', '4p', '4p', '5s', '5s', '6s', '6s', '東', '東'];
+    const fu = calculateFu(tiles, '東', false, true);
+    expect(fu).toBe(25);
+  });
+
+  it('enforces 30 fu minimum for open hands', () => {
+    const tiles: Tile[] = ['2m', '3m', '4m', '5m', '6m', '7m', '2p', '3p', '4p', '5p', '5p'];
+    const melds = [{ type: 'pon' as const, tiles: ['東', '東', '東'] }];
+    const fu = calculateFu(tiles, '5p', false, false, undefined, undefined, melds);
+    expect(fu).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe('calculateFinalScore', () => {
+  it('computes child ron below mangan', () => {
+    expect(calculateFinalScore(3, 30, false, false)).toBe('3900点');
+  });
+
+  it('computes child tsumo mangan', () => {
+    expect(calculateFinalScore(5, 30, false, true)).toBe('子: 2000点、親: 4000点（合計8000点）');
+  });
+});
+
+describe('calculateScore validations', () => {
+  it('errors when hand size is invalid', () => {
+    const result = calculateScore(['1m', '2m'], '3m', baseOptions);
+    expect('error' in result).toBe(true);
+  });
+
+  it('errors when no yaku are present', () => {
+    const hand: Tile[] = ['1m', '2m', '3m', '4m', '5m', '6m', '7p', '8p', '9p', '2s', '3s', '4s', '5m'];
+    const result = calculateScore(hand, '5m', { ...baseOptions, isRiichi: false, isTsumo: false });
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toBe('役がありません');
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #7.

## 変更点
- 役判定や点数計算の主要関数を対象にユニットテストを追加
- `calculateScore` のバリデーションケースや複数の役を網羅する統合テストを新規作成
- テストフレームワークとして導入済みの Vitest を活用し、合計 18 シナリオをカバー

## テスト
- `npm run lint`
- `npm run test`
