### PR TITLE
Use shared tile table for meld and dora

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,6 +72,13 @@ h1 {
   gap: 16px;
 }
 
+.tile-select-modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
 .sticky-actions {
   position: sticky;
   top: 16px;
@@ -191,40 +198,6 @@ h1 {
 .tile--mini {
   width: clamp(28px, 6vw, 38px);
   height: clamp(40px, 8vw, 54px);
-}
-
-.tile.is-disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.tile-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-bottom: 8px;
-}
-
-.tile-tab {
-  border: 1px solid #d6dbe3;
-  background: #fff;
-  border-radius: 999px;
-  padding: 4px 10px;
-  font-size: 0.85em;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.tile-tab.is-active {
-  background: #667eea;
-  color: white;
-  border-color: #667eea;
-}
-
-.tile-tab:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .tile.selected {


### PR DESCRIPTION
## Summary\n- add a selection mode to reuse the main tile table for hand/meld/dora picks\n- remove separate meld and dora pickers in favor of the shared table\n- keep selection limits and riichi gating for ura dora\n\nCloses #71