### PR TITLE
Fix CI type error in score quiz

### DIFF
--- a/app/score-quiz/page.tsx
+++ b/app/score-quiz/page.tsx
@@ -149,7 +149,7 @@ const pickRandomMeld = (includeHonors = true): Tile[] => {
   return pickRandomTriplet(includeHonors);
 };
 
-const pickSuitPair = (numbers = SUIT_NUMBERS): Tile[] => {
+const pickSuitPair = (numbers: readonly number[] = SUIT_NUMBERS): Tile[] => {
   const suit = pickOne(SUITS);
   const num = pickOne(numbers);
   return [`${num}${suit}`, `${num}${suit}`];


### PR DESCRIPTION
## 概要
- score-quiz の手牌生成で `pickSuitPair` の引数型が狭すぎたためビルドが失敗していたので修正。

## 変更点
- `pickSuitPair` の引数型を `readonly number[]` に拡張。

## 確認方法
- CI の build が通ることを確認。