### PR TITLE
Fix type for sequence start pool

### DIFF
--- a/app/score-quiz/page.tsx
+++ b/app/score-quiz/page.tsx
@@ -128,7 +128,7 @@ const buildSequence = (suit: typeof SUITS[number], start: number): Tile[] => [
 
 const buildTriplet = (tile: Tile): Tile[] => [tile, tile, tile];
 
-const pickRandomSequence = (startPool = SEQUENCE_STARTS): Tile[] => {
+const pickRandomSequence = (startPool: readonly number[] = SEQUENCE_STARTS): Tile[] => {
   const suit = pickOne(SUITS);
   const start = pickOne(startPool);
   return buildSequence(suit, start);


### PR DESCRIPTION
## 概要
- `pickRandomSequence` の引数型が狭く、`NON_EDGE_SEQUENCE_STARTS` を渡すと型エラーになるため修正。

## 変更点
- `pickRandomSequence` の引数型を `readonly number[]` に拡張。

## 確認方法
- CI の build が通ることを確認。