### PR TITLE
Disable review-comment workflow

### DIFF
--- a/.github/workflows/review-comment.yml
+++ b/.github/workflows/review-comment.yml
@@ -1,8 +1,7 @@
-name: Review Insights
+name: Review Insights (Disabled)
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   review:


### PR DESCRIPTION
## 概要
- review-comment ワークフローを無効化。

## 変更点
- pull_request トリガーを外し、手動実行のみ。

## 確認方法
- PRを開いても review-comment ワークフローが走らないことを確認。